### PR TITLE
Add retries for Alienvault OTX

### DIFF
--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -1,7 +1,0 @@
----
-title: "Overview"
-date: 2022-02-05T14:03:08+11:00
-draft: false
----
-
-testt

--- a/function/alienvaultotx/main_test.go
+++ b/function/alienvaultotx/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"github.com/gyrospectre/squyre/pkg/squyre"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +17,7 @@ var (
 	mockResponse string
 	TestAlert    squyre.Alert
 	ctx          context.Context
+	attempt      int
 )
 
 func mockInitClient() (*apiClient, error) {
@@ -41,6 +43,18 @@ func mockInfo(c *apiClient, indicator string, indicatorType string) (*http.Respo
 				Name: "test",
 			},
 		}
+	} else if indicator == "1.1.1.1" {
+		if attempt < 3 {
+			attempt += 1
+			return nil, errors.New("(Client.Timeout exceeded while awaiting headers)")
+		}
+		otxResp.PulseInfo.Count = 1
+		otxResp.PulseInfo.Pulses = []otxPulse{
+			{
+				Id:   "7890",
+				Name: "test2",
+			},
+		}
 	} else {
 		otxResp.PulseInfo.Count = 0
 	}
@@ -48,6 +62,7 @@ func mockInfo(c *apiClient, indicator string, indicatorType string) (*http.Respo
 	otxRespJson, _ := json.Marshal(otxResp)
 	mockResponse = string(otxRespJson)
 
+	attempt += 1
 	return &http.Response{
 		Body: ioutil.NopCloser(bytes.NewReader([]byte(mockResponse))),
 	}, nil
@@ -64,6 +79,7 @@ func setup() {
 		URL:        "https://127.0.0.1/test.html",
 		Timestamp:  "2022-12-12 18:00:00",
 	}
+	attempt = 1
 }
 
 func TestHandlerNonMatchNonIgnore(t *testing.T) {
@@ -82,7 +98,7 @@ func TestHandlerNonMatchNonIgnore(t *testing.T) {
 
 	have := response.Results[0].Message
 	json.Unmarshal([]byte(mockResponse), &responseObject)
-	want := "Indictor not found in Alienvault OTX."
+	want := "Indicator not found in Alienvault OTX."
 
 	if have != want {
 		t.Errorf("Expected '%s', got '%s'", want, have)
@@ -161,9 +177,37 @@ func TestMultiSubject(t *testing.T) {
 	}
 
 	have = respAlert.Results[1].Message
-	want = "Indictor not found in Alienvault OTX."
+	want = "Indicator not found in Alienvault OTX."
 
 	if have != want {
 		t.Fatalf("unexpected output. \nHave: %s\nWant: %s", have, want)
+	}
+}
+
+// Fail lookups the first two attempts, then work on the 3rd
+func TestTempTimeout(t *testing.T) {
+	setup()
+
+	TestAlert.Subjects = []squyre.Subject{
+		{
+			Type:  "ipv4",
+			Value: "1.1.1.1",
+		},
+	}
+	output, _ := handleRequest(ctx, TestAlert)
+
+	var response squyre.Alert
+	json.Unmarshal([]byte(output), &response)
+
+	have := response.Results[0].Message
+	json.Unmarshal([]byte(mockResponse), &responseObject)
+	want := messageFromResponse(responseObject)
+
+	if have != want {
+		t.Errorf("Expected '%s', got '%s'", want, have)
+	}
+
+	if attempt-1 != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempt-1)
 	}
 }


### PR DESCRIPTION
OTX is a bit funny, and lookups occasionally timeout. With timeouts already set at 30sec, decided to instead implement a retry mechanism; failed lookups will be retried up to 3 times before we give up. 