### PR TITLE
Extend Result Object

### DIFF
--- a/pkg/squyre/squyre.go
+++ b/pkg/squyre/squyre.go
@@ -12,10 +12,11 @@ type Subject struct {
 
 // Result holds enrichment results, and where they came from
 type Result struct {
-	Source         string
-	AttributeValue string
-	Message        string
-	Success        bool
+	Source         string // The service the result came from
+	AttributeValue string // The attribute used to search
+	Message        string // The response from the service
+	Success        bool   // Whether the lookup succeeded or not i.e. an error was encountered
+	MatchFound     bool   // Whether we found a match for this attribute on this service
 }
 
 // Alert holds information about an incoming alert


### PR DESCRIPTION
In preparation for resolving https://github.com/gyrospectre/squyre/issues/15, the Results object needs to be extended with another attribute "MatchFound".

Previously, "Success" was used to show whether a match was found on that provider for the object we looked up. This is misleading! Instead, we'll move to use "Success" to show if the lookup failed or not, and "MatchFound" to indicate if the indicator was found. Much more intuitive.