### PR TITLE
Feature/safelinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,4 @@ Check out the docs at https://gyrospectre.github.io/squyre/ for more information
 You can also check out the following generic overview, over at Medium! https://v22bis.medium.com/avoiding-security-alert-hell-introducing-squyre-b8add502e3c6
 
 ## Enrichment Functions
-It's easy to add enrichment functions, and more will be added over time. Feel free to PR and contribute!
-
-Currently supported:
-- Alienvault OTX (https://otx.alienvault.com/) : Open Threat Exchange is the neighborhood watch of the global intelligence community. (Indicator types: ipv4, domain, url)
-- Greynoise (https://www.greynoise.io/) : Tells security analysts what not to worry about. (Indicator types: ipv4)
-- IP API (https://ipapi.com/) : IP address geolocation information. (Indicator types: ipv4)
-- CrowdStrike Falcon (https://www.crowdstrike.com/endpoint-security-products/falcon-platform/) : Primarily utilising Falcon X for threat intelligence. (Indicator types: ipv4, domain, sha256, hostname)
+It's easy to add enrichment functions, and more will be added over time. See https://gyrospectre.github.io/squyre/functions/ for a list of current providers.

--- a/conductor/main_test.go
+++ b/conductor/main_test.go
@@ -297,17 +297,19 @@ func TestUrlExtraction(t *testing.T) {
 	setup()
 	url1 := "http://google.com/test/awesome?test"
 	url2 := "https://github.com/gyrospectre/squyre"
+	url3 := "https://apc04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76&data=02%7C01%7Cwoot.woot%40test.com%7C2990160b578248181f4008d79461f071%7C4f4f4c56a772461a967e7890c3960b3a%7C1%7C1%7C637141020687342499&sdata=MNYejoOQbAVPTD1ijNbwMIfl8LV8E4JlP396Pm4470E%3D&reserved=0"
 
 	str1 := "ABC 12345"
 	str2 := "ABC " + url1
 	str3 := url2
+	str4 := url3
 
-	message := str1 + " " + " [" + str2 + ", " + str3 + "] " + str2 + "}"
+	message := str1 + " " + " [" + str2 + ", " + str3 + "] " + str2 + "} " + str4
 	subjects := extractUrls(message)
 
 	have := len(subjects)
 
-	want := 2
+	want := 3
 	if have != want {
 		t.Fatalf("Unexpected number of Urls. \nHave: %x\nWant: %x", have, want)
 	}
@@ -318,5 +320,41 @@ func TestUrlExtraction(t *testing.T) {
 
 	if subjects[1].Value != url2 {
 		t.Fatalf("Unxpected second Url. \nHave: %s\nWant: %s", subjects[1].Value, url2)
+	}
+
+	wantUrl := "https://docs.testsite.int/file/im0w22da6434202ce486e98ae85196b5ccc76"
+	if subjects[2].Value != wantUrl {
+		t.Fatalf("Unxpected third Url. \nHave: %s\nWant: %s", subjects[2].Value, wantUrl)
+	}
+}
+
+func TestMalformedATPUrl(t *testing.T) {
+	setup()
+	url1 := "https://apc04.safelinks.protection.outlook.com/?rl=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76"
+	url2 := "https://apc04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76data=02%7C01%7Cwoot.woot%40test.com%7C2990160b578248181f4008d79461f071%7C4f4f4c56a772461a967e7890c3960b3a%7C1%7C1%7C637141020687342499sdata=MNYejoOQbAVPTD1ijNbwMIfl8LV8E4JlP396Pm4470E%3Dreserved=0"
+	url3 := "https://apc04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76&data=02%7C01%7Cwoot.woot%40test.com%7C2990160b578248181f4008d79461f071%7C4f4f4c56a772461a967e7890c3960b3a%7C1%7C1%7C637141020687342499&sdata=MNYejoOQbAVPTD1ijNbwMIfl8LV8E4JlP396Pm4470E%3D&reserved=0"
+
+	message := "ABC " + url1 + ": " + url2 + " { " + url3
+
+	subjects := extractUrls(message)
+
+	have := len(subjects)
+	want := 3
+
+	if have != want {
+		t.Fatalf("Unexpected number of Urls. \nHave: %x\nWant: %x", have, want)
+	}
+
+	if subjects[0].Value != url1 {
+		t.Fatalf("Unxpected first Url. \nHave: %s\nWant: %s", subjects[0].Value, url1)
+	}
+
+	if subjects[1].Value != url2 {
+		t.Fatalf("Unxpected second Url. \nHave: %s\nWant: %s", subjects[1].Value, url2)
+	}
+
+	wantUrl := "https://docs.testsite.int/file/im0w22da6434202ce486e98ae85196b5ccc76"
+	if subjects[2].Value != wantUrl {
+		t.Fatalf("Unxpected third Url. \nHave: %s\nWant: %s", subjects[2].Value, wantUrl)
 	}
 }

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -6,7 +6,7 @@ draft: false
 
 Squyre is serverless, and uses AWS services SNS, API Gateway, Lambda and Step Functions to do it's thing.
 
-Alerts are sent in via SNS or Webhook, which triggers the first Lambda function, `conductor`. This function takes the alert body, extracts IP addresses, domain names, URLs and hostnames, and then starts the step function with this information.
+Alerts are sent in via SNS or Webhook, which triggers the first Lambda function, `conductor`. This function takes the alert body, extracts IP addresses, domain names, URLs and hostnames, and then starts the step function with this information. Note that any Microsoft 365 ATP Safe Links are also converted into their original URLs at this stage.
 
 The step function (or state machine) then invokes enrichment functions depending on what sort of info was in the alert. There are currently two categories of functions:
 

--- a/docs/content/architecture/state.md
+++ b/docs/content/architecture/state.md
@@ -8,6 +8,6 @@ The main state machine is called `EnrichStateMachine`, because it, uh enriches, 
 
 It is defined by `statemachine/enrich.asl.json` in the [AWS ASL language](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-states-language.html).
 
-Layout is straightforward, nested parallel branches run the enrichment tasks which are sent to the output function at the end to update alerts/tickets.
+Layout is straightforward; nested parallel branches run the enrichment tasks which are sent to the output function at the end to update alerts/tickets.
 
 <img src="/squyre/media/statemachine.png" alt="Enrich State Machine" width="75%" />

--- a/event/url-alert.json
+++ b/event/url-alert.json
@@ -1,0 +1,14 @@
+{
+    "Timestamp": "",
+    "Name": "Test Alert",
+    "RawMessage": "127.0.0.1 172.17.0.1 202.92.65.254,_audit",
+    "Url": "http://127.0.0.1:8000/app/search/@go?sid=scheduler_blah",
+    "Id": "d37dd17e-8886-4add-85c1-38f6cfeb0aa3-1641081155358",
+    "Subjects": [
+      {
+        "Type": "url",
+        "Value": "https://apc04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76&data=02%7C01%7CMark.Juchnowski%40epicor.com%7C2990160b578248181f4008d79461f071%7C4f4f4c56a772461a967e7890c3960b3a%7C1%7C1%7C637141020687342499&sdata=MNYejoOQbAVPTD1ijNbwMIfl8LV8E4JlP396Pm4470E%3D&reserved=0"
+      }
+    ],
+    "Results": null
+}

--- a/event/url-alert.json
+++ b/event/url-alert.json
@@ -7,7 +7,7 @@
     "Subjects": [
       {
         "Type": "url",
-        "Value": "https://apc04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76&data=02%7C01%7CMark.Juchnowski%40epicor.com%7C2990160b578248181f4008d79461f071%7C4f4f4c56a772461a967e7890c3960b3a%7C1%7C1%7C637141020687342499&sdata=MNYejoOQbAVPTD1ijNbwMIfl8LV8E4JlP396Pm4470E%3D&reserved=0"
+        "Value": "https://apc04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.testsite.int%2Ffile%2Fim0w22da6434202ce486e98ae85196b5ccc76&data=02%7C01%7Cwoot.woot%40test.com%7C2990160b578248181f4008d79461f071%7C4f4f4c56a772461a967e7890c3960b3a%7C1%7C1%7C637141020687342499&sdata=MNYejoOQbAVPTD1ijNbwMIfl8LV8E4JlP396Pm4470E%3D&reserved=0"
       }
     ],
     "Results": null

--- a/scripts/bootstrap/main.go
+++ b/scripts/bootstrap/main.go
@@ -145,7 +145,6 @@ func main() {
 	}
 
 	if state.MultiTasks == "" {
-		fmt.Println("here-multi")
 		buf := new(bytes.Buffer)
 		err = pass.Execute(buf, &sqFunc{
 			Type: "multipurpose",
@@ -157,7 +156,6 @@ func main() {
 	}
 
 	if state.IPv4Tasks == "" {
-		fmt.Println("here-ipv4")
 		buf := new(bytes.Buffer)
 		err = pass.Execute(buf, &sqFunc{
 			Type: "ipv4",


### PR DESCRIPTION
Adding a nice little conversion feature; the `conductor` function will now detect Microsoft 365 ATP Safe Links, and convert them to their original value prior to enrichment. This means lookups are done on the real URL, not the obfuscated version. Nice.