### PR TITLE
Fix failing test, and return correct exit code from test runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.17
+        go-version: 1.22
 
     - name: Build
       run: sam build -u

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ deploy-guided:
 
 test:
 	@echo "go test all packages"
-	@for DIR in $(GODIRS); do cd $$DIR; go test ${TEST_TIMEOUT} -cover -v -count=1; cd - > /dev/null ; done;
+	@for DIR in $(GODIRS); \
+		do cd $$DIR; \
+		go test ${TEST_TIMEOUT} -cover -v -count=1; \
+		if [ $$? -ne 0 ]; then echo "Test failed for $$DIR"; exit 1; fi; \
+		cd - > /dev/null ; \
+	done;
 
 setup:
 	@echo "run Squyre setup"

--- a/function/alienvaultotx/main_test.go
+++ b/function/alienvaultotx/main_test.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/gyrospectre/squyre/pkg/squyre"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gyrospectre/squyre/pkg/squyre"
 )
 
 var (
@@ -87,7 +88,7 @@ func setup(t *testing.T) {
 }
 
 func TestHandlerNonMatchNonIgnore(t *testing.T) {
-	setup()
+	setup(t)
 
 	TestAlert.Subjects = []squyre.Subject{
 		{


### PR DESCRIPTION
The last merge should have failed unit tests, but tests were showing as passing. Fixed the issue causing test fails, and also upated the Makefile so that unit test failures will cause the action to fail as well (so we know when breakages happen!).